### PR TITLE
Add `micromark-util-types` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "fault": "^2.0.0",
     "micromark-util-character": "^1.0.0",
-    "micromark-util-symbol": "^1.0.0"
+    "micromark-util-symbol": "^1.0.0",
+    "micromark-util-types": "^1.0.0"
   },
   "devDependencies": {
     "@types/tape": "^4.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Various type imports directly reference `micromark-util-types`: https://github.com/micromark/micromark-extension-frontmatter/blob/07a4d981df602f558f05cd8bafe1be4b57fea072/dev/lib/syntax.js#L2-L6

Since it isn't listed in the dependencies, loose package managers like npm may generate incorrect hoisting (so TS would resolve the wrong version of `micromark-util-types`), and strict package managers like Yarn or pnpm may cause TS to fail to resolve the dependency.

This diff simply adds the missing dependency.

<!--do not edit: pr-->
